### PR TITLE
Fix headlights, turn signals, and misc lights

### DIFF
--- a/apollo/Makefile
+++ b/apollo/Makefile
@@ -11,7 +11,8 @@ SOURCES += $(STD_DRIVERS)/commsLib.c \
 SOURCES += $(STD_PERIPHS)/spi.c \
 			$(STD_PERIPHS)/systemClock.c
 
-SOURCES += $(DRIVERS)/comms.c
+SOURCES += $(DRIVERS)/comms.c \
+		   $(DRIVERS)/lights.c
 
 SOURCES += $(HAL)/src/stm32f0xx_hal_rcc.c \
 			$(HAL)/src/stm32f0xx_hal_rcc_ex.c \

--- a/apollo/drivers/lights.c
+++ b/apollo/drivers/lights.c
@@ -1,85 +1,112 @@
 #include "stm32f0xx_hal.h"
 #include "lights.h"
 
-//Look up table for PWMing the lights 
+//Look up table for PWMing the lights
 uint16_t arr[256] = {
-    24000, 23905, 23811, 23717, 23623, 23529, 23435, 23341,
-    23247, 23152, 23058, 22964, 22870, 22776, 22682, 22588,
-    22494, 22400, 22305, 22211, 22117, 22023, 21929, 21835,
-    21741, 21647, 21552, 21458, 21364, 21270, 21176, 21082,
-    20988, 20894, 20800, 20705, 20611, 20517, 20423, 20329,
-    20235, 20141, 20047, 19952, 19858, 19764, 19670, 19576,
-    19482, 19388, 19294, 19200, 19105, 19011, 18917, 18823,
-    18729, 18635, 18541, 18447, 18352, 18258, 18164, 18070,
-    17976, 17882, 17788, 17694, 17600, 17505, 17411, 17317,
-    17223, 17129, 17035, 16941, 16847, 16752, 16658, 16564,
-    16470, 16376, 16282, 16188, 16094, 16000, 15905, 15811,
-    15717, 15623, 15529, 15435, 15341, 15247, 15152, 15058,
-    14964, 14870, 14776, 14682, 14588, 14494, 14400, 14305,
-    14211, 14117, 14023, 13929, 13835, 13741, 13647, 13552,
-    13458, 13364, 13270, 13176, 13082, 12988, 12894, 12800,
-    12705, 12611, 12517, 12423, 12329, 12235, 12141, 12047,
-    11952, 11858, 11764, 11670, 11576, 11482, 11388, 11294,
-    11200, 11105, 11011, 10917, 10823, 10729, 10635, 10541,
-    10447, 10352, 10258, 10164, 10070, 9976,  9882,  9788,
-    9694,  9600,  9505,  9411,  9317,  9223,  9129,  9035,
-    8941,  8847,  8752,  8658,  8564,  8470,  8376,  8282,
-    8188,  8094,  8000,  7905,  7811,  7717,  7623,  7529,
-    7435,  7341,  7247,  7152,  7058,  6964,  6870,  6776,
-    6682,  6588,  6494,  6400,  6305,  6211,  6117,  6023,
-    5929,  5835,  5741,  5647,  5552,  5458,  5364,  5270,
-    5176,  5082,  4988,  4894,  4800,  4705,  4611,  4517,
-    4423,  4329,  4235,  4141,  4047,  3952,  3858,  3764,
-    3670,  3576,  3482,  3388,  3294,  3200,  3105,  3011,
-    2917,  2823,  2729,  2635,  2541,  2447,  2352,  2258,
-    2164,  2070,  1976,  1882,  1788,  1694,  1600,  1505,
-    1411,  1317,  1223,  1129,  1035,  941,   847,   752,
-    658,   564,   470,   376,   282,   188,   94,    0
-};
-
+    0,     94,    188,   282,   376,   470,   564,   658,
+    752,   847,   941,   1035,  1129,  1223,  1317,  1411,
+    1505,  1600,  1694,  1788,  1882,  1976,  2070,  2164,
+    2258,  2352,  2447,  2541,  2635,  2729,  2823,  2917,
+    3011,  3105,  3200,  3294,  3388,  3482,  3576,  3670,
+    3764,  3858,  3952,  4047,  4141,  4235,  4329,  4423,
+    4517,  4611,  4705,  4800,  4894,  4988,  5082,  5176,
+    5270,  5364,  5458,  5552,  5647,  5741,  5835,  5929,
+    6023,  6117,  6211,  6305,  6400,  6494,  6588,  6682,
+    6776,  6870,  6964,  7058,  7152,  7247,  7341,  7435,
+    7529,  7623,  7717,  7811,  7905,  8000,  8094,  8188,
+    8282,  8376,  8470,  8564,  8658,  8752,  8847,  8941,
+    9035,  9129,  9223,  9317,  9411,  9505,  9600,  9694,
+    9788,  9882,  9976,  10070, 10164, 10258, 10352, 10447,
+    10541, 10635, 10729, 10823, 10917, 11011, 11105, 11200,
+    11294, 11388, 11482, 11576, 11670, 11764, 11858, 11952,
+    12047, 12141, 12235, 12329, 12423, 12517, 12611, 12705,
+    12800, 12894, 12988, 13082, 13176, 13270, 13364, 13458,
+    13552, 13647, 13741, 13835, 13929, 14023, 14117, 14211,
+    14305, 14400, 14494, 14588, 14682, 14776, 14870, 14964,
+    15058, 15152, 15247, 15341, 15435, 15529, 15623, 15717,
+    15811, 15905, 16000, 16094, 16188, 16282, 16376, 16470,
+    16564, 16658, 16752, 16847, 16941, 17035, 17129, 17223,
+    17317, 17411, 17505, 17600, 17694, 17788, 17882, 17976,
+    18070, 18164, 18258, 18352, 18447, 18541, 18635, 18729,
+    18823, 18917, 19011, 19105, 19200, 19294, 19388, 19482,
+    19576, 19670, 19764, 19858, 19952, 20047, 20141, 20235,
+    20329, 20423, 20517, 20611, 20705, 20800, 20894, 20988,
+    21082, 21176, 21270, 21364, 21458, 21552, 21647, 21741,
+    21835, 21929, 22023, 22117, 22211, 22305, 22400, 22494,
+    22588, 22682, 22776, 22870, 22964, 23058, 23152, 23247,
+    23341, 23435, 23529, 23623, 23717, 23811, 23905, 24000
+}
 
 void init_Timer(){
 
+    /* enable GPIOA and GPIOB clocks */
     __HAL_RCC_GPIOA_CLK_ENABLE();
     __HAL_RCC_GPIOB_CLK_ENABLE();
 
+    /* enable TIM2 clock */
     __HAL_RCC_TIM2_CLK_ENABLE();
+    /* set output compare modes for compare 1, 2, and 3 to '111' (PWM mode 2) */
+    TIM2 -> CCMR1 = (TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_0) |
+                    (TIM_CCMR1_OC2M_2 | TIM_CCMR1_OC2M_1 | TIM_CCMR1_OC2M_0);
     TIM2 -> CCMR2 = (TIM_CCMR2_OC3M_2 | TIM_CCMR2_OC3M_1 | TIM_CCMR2_OC3M_0);
-    TIM2 -> CCMR1 = (TIM_CCMR1_OC2M_2 | TIM_CCMR1_OC2M_1 | TIM_CCMR1_OC2M_0 |
-                     TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_0);
+    /* enable capture/compare output for compare 1, 2, and 3 */
     TIM2 -> CCER = (TIM_CCER_CC3E_Msk | TIM_CCER_CC2E_Msk | TIM_CCER_CC1E_Msk);
+    /* enable counter */
     TIM2 -> CR1 = TIM_CR1_CEN;
+    /* set auto-reload to 24000 (max. PWM value) */
     TIM2 -> ARR = 24000;
+    /* initialize capture/compare registers for channel 1 and 2 to 24000 */
     TIM2 -> CCR1 = 24000;
     TIM2 -> CCR2 = 24000;
 
+    /* enable TIM3 clock */
     __HAL_RCC_TIM3_CLK_ENABLE();
-    TIM3 -> CCMR1 = (TIM_CCMR1_OC2M_2 | TIM_CCMR1_OC2M_1 | TIM_CCMR1_OC2M_0) |
-                    (TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_0);
+    /* set output compare modes for compare 1 and 2 to '111' (PWM mode 2) */
+    TIM3 -> CCMR1 = (TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_0) |
+                    (TIM_CCMR1_OC2M_2 | TIM_CCMR1_OC2M_1 | TIM_CCMR1_OC2M_0);
+    /* enable capture/compare output for compare 1 and 2 */
     TIM3 -> CCER = (TIM_CCER_CC2E_Msk | TIM_CCER_CC1E_Msk);
+    /* enable counter */
     TIM3 -> CR1 = TIM_CR1_CEN;
+    /* set auto-reload to 24000 (max. PWM value) */
     TIM3 -> ARR = 24000;
+    /* initialize capture/compare registers for channel 1 and 2 to 24000 */
     TIM3 -> CCR1 = 24000;
     TIM3 -> CCR2 = 24000;
 
+    /* enable TIM16 clock */
     __HAL_RCC_TIM16_CLK_ENABLE();
+    /* set output compare mode for compare 1 to '111' (PWM mode 2) */
     TIM16 -> CCMR1 = (TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_0);
+    /* enable main output in break and dead-time register */
     TIM16 -> BDTR = TIM_BDTR_MOE_Msk;
+    /* enable capture/compare and complementary output for compare 1 */
     TIM16 -> CCER = TIM_CCER_CC1E_Msk | TIM_CCER_CC1NE_Msk;
+    /* enable counter */
     TIM16 -> CR1 = TIM_CR1_CEN;
+    /* set auto-reload to 24000 (max. PWM value) */
     TIM16 -> ARR = 24000;
+    /* initialize capture/compare registers for channel 1 to 24000 */
     TIM16 -> CCR1 = 24000;
 
+    /* enable TIM17 clock */
     __HAL_RCC_TIM17_CLK_ENABLE();
+    /* set output compare mode for compare 1 to '111' (PWM mode 2) */
     TIM17 -> CCMR1 = (TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_0);
+    /* enable main output in break and dead-time register */
     TIM17 -> BDTR = TIM_BDTR_MOE_Msk;
+    /* enable capture/compare and complementary output for compare 1 */
     TIM17 -> CCER = TIM_CCER_CC1E_Msk | TIM_CCER_CC1NE_Msk;
+    /* enable counter */
     TIM17 -> CR1 = TIM_CR1_CEN;
+    /* set auto-reload to 24000 (max. PWM value) */
     TIM17 -> ARR = 24000;
+    /* initialize capture/compare registers for channel 1 to 24000 */
     TIM17 -> CCR1 = 24000;
 
     GPIO_InitTypeDef GPIO_InitTypeDef;
 
+    /* configure GPIO for HEADLIGHTS */
     GPIO_InitTypeDef.Pin = HEADLIGHTS;
     GPIO_InitTypeDef.Pull = GPIO_NOPULL;
     GPIO_InitTypeDef.Mode = GPIO_MODE_AF_PP;
@@ -87,6 +114,7 @@ void init_Timer(){
     GPIO_InitTypeDef.Alternate = GPIO_AF2_TIM2;
     HAL_GPIO_Init( TURN_SIGNAL_PORT, &GPIO_InitTypeDef );
 
+    /* configure GPIO for MISC1 */
     GPIO_InitTypeDef.Pin = MISC1;
     GPIO_InitTypeDef.Pull = GPIO_NOPULL;
     GPIO_InitTypeDef.Mode = GPIO_MODE_AF_PP;
@@ -94,6 +122,7 @@ void init_Timer(){
     GPIO_InitTypeDef.Alternate = GPIO_AF2_TIM2;
     HAL_GPIO_Init( TURN_SIGNAL_PORT, &GPIO_InitTypeDef );
 
+    /* configure GPIO for MISC2 */
     GPIO_InitTypeDef.Pin = MISC2;
     GPIO_InitTypeDef.Pull = GPIO_NOPULL;
     GPIO_InitTypeDef.Mode = GPIO_MODE_AF_PP;
@@ -101,6 +130,7 @@ void init_Timer(){
     GPIO_InitTypeDef.Alternate = GPIO_AF2_TIM2;
     HAL_GPIO_Init( MISC_PORT, &GPIO_InitTypeDef );
 
+    /* configure GPIO for MISC3 and 4 */
     GPIO_InitTypeDef.Pin = (MISC3 | MISC4);
     GPIO_InitTypeDef.Pull = GPIO_NOPULL;
     GPIO_InitTypeDef.Mode = GPIO_MODE_AF_PP;
@@ -108,6 +138,7 @@ void init_Timer(){
     GPIO_InitTypeDef.Alternate = GPIO_AF1_TIM3;
     HAL_GPIO_Init( MISC_PORT, &GPIO_InitTypeDef );
 
+    /* configure GPIO for MISC5 */
     GPIO_InitTypeDef.Pin = MISC5;
     GPIO_InitTypeDef.Pull = GPIO_NOPULL;
     GPIO_InitTypeDef.Mode = GPIO_MODE_AF_PP;
@@ -115,6 +146,7 @@ void init_Timer(){
     GPIO_InitTypeDef.Alternate = GPIO_AF2_TIM16;
     HAL_GPIO_Init( MISC_PORT, &GPIO_InitTypeDef );
 
+    /* configure GPIO for MISC6 */
     GPIO_InitTypeDef.Pin = MISC6;
     GPIO_InitTypeDef.Pull = GPIO_NOPULL;
     GPIO_InitTypeDef.Mode = GPIO_MODE_AF_PP;
@@ -122,6 +154,7 @@ void init_Timer(){
     GPIO_InitTypeDef.Alternate = GPIO_AF2_TIM17;
     HAL_GPIO_Init( MISC_PORT, &GPIO_InitTypeDef );
 
+    /* configure GPIO for turn signals */
     GPIO_InitTypeDef.Pin = (TURN_SIGNAL_L | TURN_SIGNAL_R);
     GPIO_InitTypeDef.Pull = GPIO_NOPULL;
     GPIO_InitTypeDef.Mode = GPIO_MODE_OUTPUT_PP;
@@ -134,7 +167,6 @@ void init_Timer(){
 
 void init_apollo(){
     init_Timer();
-
 }
 
 void set_turn_signal(uint8_t state){
@@ -153,32 +185,32 @@ void set_turn_signal(uint8_t state){
 }
 
 void set_headlights( uint8_t speed){
-    TIM2 -> CCR1 = arr[255 - speed];
+    TIM2 -> CCR1 = arr[speed];
 }
 
 void set_misc_lights(uint8_t light, uint8_t speed){
     if (light == 0){
-        TIM2 -> CCR1 = arr[255 - speed];
+        TIM2 -> CCR1 = arr[speed];
     }
 
     if (light == 1){
-        TIM2 -> CCR2 = arr[255 - speed];
+        TIM2 -> CCR2 = arr[speed];
     }
 
     if (light == 2){
-        TIM3 -> CCR1 = arr[255 - speed];
+        TIM3 -> CCR1 = arr[speed];
     }
 
     if (light == 3){
-        TIM3 -> CCR2 = arr[255 - speed];
+        TIM3 -> CCR2 = arr[speed];
     }
 
     if (light == 4){
-        TIM16 -> CCR1 = arr[speed];
+        TIM16 -> CCR1 = arr[255 - speed]; /* inverted to correct PWM */
     }
 
     if (light == 5){
-        TIM17 -> CCR1 = arr[speed];
+        TIM17 -> CCR1 = arr[255 - speed]; /* inverted to correct PWM */
     }
 }
 

--- a/apollo/drivers/lights.c
+++ b/apollo/drivers/lights.c
@@ -40,99 +40,93 @@ uint16_t arr[256] = {
 
 void init_Timer(){
 
-    //sets up Timer 2 both channel 1 and 2
-    __HAL_RCC_TIM2_CLK_ENABLE();
-    //sets up the third channel of timer2 by oring bits in the second CCMR register.
-    TIM2 -> CCMR2 = (TIM_CCMR2_OC3M_2 | TIM_CCMR2_OC3M_1 | TIM_CCMR2_OC3M_0);
-    //sets up the second channel of timer2. OCxM shows the channel number
-    TIM2 -> CCMR1 = (TIM_CCMR1_OC2M_2 | TIM_CCMR1_OC2M_1 | TIM_CCMR1_OC2M_0);
-    //sets up the capture/compare enable register to output
-    TIM2 -> CCER = (TIM_CCER_CC3E_Msk | TIM_CCER_CC2E_Msk);
-    //sets control register 1 to be enabled
-    TIM2 -> CR1 = TIM_CR1_CEN;
-    //initializes the auto-reload register to be 24000
-    TIM2 -> ARR = 24000;
-    //initializes capture compare register 2 to be 24000
-    TIM2 -> CCR2 = 24000;
-    //''            ''      ''       ''    3 '' ''   ''
-    TIM2 -> CCR3 = 24000;
-
-    //intialize GPIOB to be enabled
-    __HAL_RCC_GPIOB_CLK_ENABLE();
-    GPIO_InitTypeDef GPIO_InitTypeDef;
-    //sets up these pins defined in the header to be outputs
-    GPIO_InitTypeDef.Pin = (HEADLIGHTS | MISC5);
-    GPIO_InitTypeDef.Pull = GPIO_NOPULL;
-    //mode is push- pull
-    GPIO_InitTypeDef.Mode = GPIO_MODE_AF_PP;
-    GPIO_InitTypeDef.Speed = GPIO_SPEED_FREQ_LOW;
-    //sets up the pins to be alternate functions as timers
-    GPIO_InitTypeDef.Alternate = GPIO_AF2_TIM2;
-    HAL_GPIO_Init( MISC_PORT, &GPIO_InitTypeDef );
-
     __HAL_RCC_GPIOA_CLK_ENABLE();
-    GPIO_InitTypeDef.Pin = (HEADLIGHTS | MISC5);
+    __HAL_RCC_GPIOB_CLK_ENABLE();
+
+    __HAL_RCC_TIM2_CLK_ENABLE();
+    TIM2 -> CCMR2 = (TIM_CCMR2_OC3M_2 | TIM_CCMR2_OC3M_1 | TIM_CCMR2_OC3M_0);
+    TIM2 -> CCMR1 = (TIM_CCMR1_OC2M_2 | TIM_CCMR1_OC2M_1 | TIM_CCMR1_OC2M_0 |
+                     TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_0);
+    TIM2 -> CCER = (TIM_CCER_CC3E_Msk | TIM_CCER_CC2E_Msk | TIM_CCER_CC1E_Msk);
+    TIM2 -> CR1 = TIM_CR1_CEN;
+    TIM2 -> ARR = 24000;
+    TIM2 -> CCR1 = 24000;
+    TIM2 -> CCR2 = 24000;
+
+    __HAL_RCC_TIM3_CLK_ENABLE();
+    TIM3 -> CCMR1 = (TIM_CCMR1_OC2M_2 | TIM_CCMR1_OC2M_1 | TIM_CCMR1_OC2M_0) |
+                    (TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_0);
+    TIM3 -> CCER = (TIM_CCER_CC2E_Msk | TIM_CCER_CC1E_Msk);
+    TIM3 -> CR1 = TIM_CR1_CEN;
+    TIM3 -> ARR = 24000;
+    TIM3 -> CCR1 = 24000;
+    TIM3 -> CCR2 = 24000;
+
+    __HAL_RCC_TIM16_CLK_ENABLE();
+    TIM16 -> CCMR1 = (TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_0);
+    TIM16 -> BDTR = TIM_BDTR_MOE_Msk;
+    TIM16 -> CCER = TIM_CCER_CC1E_Msk | TIM_CCER_CC1NE_Msk;
+    TIM16 -> CR1 = TIM_CR1_CEN;
+    TIM16 -> ARR = 24000;
+    TIM16 -> CCR1 = 24000;
+
+    __HAL_RCC_TIM17_CLK_ENABLE();
+    TIM17 -> CCMR1 = (TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_0);
+    TIM17 -> BDTR = TIM_BDTR_MOE_Msk;
+    TIM17 -> CCER = TIM_CCER_CC1E_Msk | TIM_CCER_CC1NE_Msk;
+    TIM17 -> CR1 = TIM_CR1_CEN;
+    TIM17 -> ARR = 24000;
+    TIM17 -> CCR1 = 24000;
+
+    GPIO_InitTypeDef GPIO_InitTypeDef;
+
+    GPIO_InitTypeDef.Pin = HEADLIGHTS;
     GPIO_InitTypeDef.Pull = GPIO_NOPULL;
     GPIO_InitTypeDef.Mode = GPIO_MODE_AF_PP;
     GPIO_InitTypeDef.Speed = GPIO_SPEED_FREQ_LOW;
     GPIO_InitTypeDef.Alternate = GPIO_AF2_TIM2;
     HAL_GPIO_Init( TURN_SIGNAL_PORT, &GPIO_InitTypeDef );
 
-    //sets up timer 16
-    __HAL_RCC_TIM16_CLK_ENABLE();
-    TIM16 -> CCMR1 = (TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_0);
-    TIM16 -> CCER = TIM_CCER_CC1E_Msk;
-    TIM16 -> CR1 = TIM_CR1_CEN;
-    TIM16 -> ARR = 24000;
-    TIM16 -> CCR1 = 24000;
+    GPIO_InitTypeDef.Pin = MISC1;
+    GPIO_InitTypeDef.Pull = GPIO_NOPULL;
+    GPIO_InitTypeDef.Mode = GPIO_MODE_AF_PP;
+    GPIO_InitTypeDef.Speed = GPIO_SPEED_FREQ_LOW;
+    GPIO_InitTypeDef.Alternate = GPIO_AF2_TIM2;
+    HAL_GPIO_Init( TURN_SIGNAL_PORT, &GPIO_InitTypeDef );
 
     GPIO_InitTypeDef.Pin = MISC2;
+    GPIO_InitTypeDef.Pull = GPIO_NOPULL;
+    GPIO_InitTypeDef.Mode = GPIO_MODE_AF_PP;
+    GPIO_InitTypeDef.Speed = GPIO_SPEED_FREQ_LOW;
+    GPIO_InitTypeDef.Alternate = GPIO_AF2_TIM2;
+    HAL_GPIO_Init( MISC_PORT, &GPIO_InitTypeDef );
+
+    GPIO_InitTypeDef.Pin = (MISC3 | MISC4);
+    GPIO_InitTypeDef.Pull = GPIO_NOPULL;
+    GPIO_InitTypeDef.Mode = GPIO_MODE_AF_PP;
+    GPIO_InitTypeDef.Speed = GPIO_SPEED_FREQ_LOW;
+    GPIO_InitTypeDef.Alternate = GPIO_AF1_TIM3;
+    HAL_GPIO_Init( MISC_PORT, &GPIO_InitTypeDef );
+
+    GPIO_InitTypeDef.Pin = MISC5;
     GPIO_InitTypeDef.Pull = GPIO_NOPULL;
     GPIO_InitTypeDef.Mode = GPIO_MODE_AF_PP;
     GPIO_InitTypeDef.Speed = GPIO_SPEED_FREQ_LOW;
     GPIO_InitTypeDef.Alternate = GPIO_AF2_TIM16;
     HAL_GPIO_Init( MISC_PORT, &GPIO_InitTypeDef );
 
-    __HAL_RCC_TIM3_CLK_ENABLE();
-     TIM3 -> CCMR1 = (TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_0 | TIM_CCMR1_OC2M_2 | TIM_CCMR1_OC2M_1 | TIM_CCMR1_OC2M_0);
-     TIM3 -> CCER = (TIM_CCER_CC2E_Msk | TIM_CCER_CC1E_Msk);
-     TIM3 -> CR1 = TIM_CR1_CEN;
-     TIM3 -> ARR = 24000;
-     TIM3 -> CCR1 = 24000;
-     TIM3 -> CCR2 = 24000;
-
-     __HAL_RCC_GPIOB_CLK_ENABLE();
-     GPIO_InitTypeDef.Pin = (MISC3 | MISC4);
-     GPIO_InitTypeDef.Pull = GPIO_NOPULL;
-     GPIO_InitTypeDef.Mode = GPIO_MODE_AF_PP;
-     GPIO_InitTypeDef.Speed = GPIO_SPEED_FREQ_LOW;
-     GPIO_InitTypeDef.Alternate = GPIO_AF1_TIM3;
-     HAL_GPIO_Init( MISC_PORT, &GPIO_InitTypeDef );
-
-    __HAL_RCC_TIM1_CLK_ENABLE();
-    TIM1 -> CCMR2 = (TIM_CCMR2_OC4M_2 | TIM_CCMR2_OC4M_1 | TIM_CCMR2_OC4M_0);
-    TIM1 -> CCMR1 = (TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_0);
-    TIM1 -> CCER = (TIM_CCER_CC4E_Msk | TIM_CCER_CC1E_Msk);
-    TIM1 -> CR1 = TIM_CR1_CEN;
-    TIM1 -> ARR = 24000;
-    TIM1 -> CCR4 = 24000;
-
-    __HAL_RCC_GPIOA_CLK_ENABLE();
-    GPIO_InitTypeDef.Pin = (MISC6 | MISC1);
+    GPIO_InitTypeDef.Pin = MISC6;
     GPIO_InitTypeDef.Pull = GPIO_NOPULL;
     GPIO_InitTypeDef.Mode = GPIO_MODE_AF_PP;
     GPIO_InitTypeDef.Speed = GPIO_SPEED_FREQ_LOW;
-    GPIO_InitTypeDef.Alternate = GPIO_AF2_TIM1;
-    HAL_GPIO_Init( TURN_SIGNAL_PORT, &GPIO_InitTypeDef );
+    GPIO_InitTypeDef.Alternate = GPIO_AF2_TIM17;
+    HAL_GPIO_Init( MISC_PORT, &GPIO_InitTypeDef );
 
-    __HAL_RCC_GPIOA_CLK_ENABLE();
-    GPIO_InitTypeDef.Pin =(TURN_SIGNAL_L | TURN_SIGNAL_R);
+    GPIO_InitTypeDef.Pin = (TURN_SIGNAL_L | TURN_SIGNAL_R);
     GPIO_InitTypeDef.Pull = GPIO_NOPULL;
     GPIO_InitTypeDef.Mode = GPIO_MODE_OUTPUT_PP;
     GPIO_InitTypeDef.Speed = GPIO_SPEED_FREQ_LOW;
     HAL_GPIO_Init( TURN_SIGNAL_PORT, &GPIO_InitTypeDef );
-
-    //GPIOA ->BSRR |=GPIO_PIN_
     //Start with turn signals off
     TURN_SIGNAL_PORT -> ODR &= ~(TURN_SIGNAL_L | TURN_SIGNAL_R);
 
@@ -159,32 +153,32 @@ void set_turn_signal(uint8_t state){
 }
 
 void set_headlights( uint8_t speed){
-    TIM2 -> CCR3 = arr[speed];
+    TIM2 -> CCR1 = arr[255 - speed];
 }
 
 void set_misc_lights(uint8_t light, uint8_t speed){
     if (light == 0){
-        TIM17 -> CCR1 = arr[speed];
+        TIM2 -> CCR1 = arr[255 - speed];
     }
 
     if (light == 1){
-        TIM16 -> CCR1 = arr[speed];
+        TIM2 -> CCR2 = arr[255 - speed];
     }
 
     if (light == 2){
-        TIM3 -> CCR2 = arr[speed];
+        TIM3 -> CCR1 = arr[255 - speed];
     }
 
     if (light == 3){
-        TIM3 -> CCR1 = arr[speed];
+        TIM3 -> CCR2 = arr[255 - speed];
     }
 
     if (light == 4){
-        TIM2 -> CCR2 = arr[speed];
+        TIM16 -> CCR1 = arr[speed];
     }
 
     if (light == 5){
-        TIM1 -> CCR4 = arr[speed];
+        TIM17 -> CCR1 = arr[speed];
     }
 }
 

--- a/apollo/drivers/lights.h
+++ b/apollo/drivers/lights.h
@@ -3,23 +3,23 @@
 
 #include <stdint.h>
 
-#define TURN_SIGNAL_L GPIO_PIN_1
+#define TURN_SIGNAL_L GPIO_PIN_2
 #define TURN_SIGNAL_PORT GPIOA
-#define TURN_SIGNAL_R GPIO_PIN_0
+#define TURN_SIGNAL_R GPIO_PIN_1
 
 #define STATE_R_MASK 0x01
 #define STATE_L_MASK 0x02
 
 #define MISC_PORT GPIOB
 
-#define HEADLIGHTS GPIO_PIN_2
+#define HEADLIGHTS GPIO_PIN_0
 
-#define MISC1 GPIO_PIN_8//GPIOA
-#define MISC2 GPIO_PIN_9//GPIOA
-#define MISC3 GPIO_PIN_5
-#define MISC4 GPIO_PIN_4
-#define MISC5 GPIO_PIN_3
-#define MISC6 GPIO_PIN_11
+#define MISC1 GPIO_PIN_15//GPIOA
+#define MISC2 GPIO_PIN_3 //GPIOB
+#define MISC3 GPIO_PIN_4
+#define MISC4 GPIO_PIN_5
+#define MISC5 GPIO_PIN_6
+#define MISC6 GPIO_PIN_7
 
 void init_apollo();
 


### PR DESCRIPTION
This change moves the GPIO ports around and enables the proper timers to get
the headlights, turn signals, and misc lights on the proper ports. It
also adds index inversion on MISC 1-4 (since TIM16 and TIM17 on MISC 5
and 6 already do this for some reason) to make the "set_headlights" and
"set_misc_lights" work on brightness and not "darkness" like it was
before (i.e. set_misc_lights(255) should not be off).

* Update Makefile
* Update lights.c/h