### PR TITLE
[I69] Olympus: Add new commsSetSpeed

### DIFF
--- a/olympus/drivers/comms.c
+++ b/olympus/drivers/comms.c
@@ -53,10 +53,7 @@ static void commsSetTurnSignal(uint8_t* data){return;}
 static void commsSetHeadlights(uint8_t* data){return;}
 static void commsSetMiscLights(uint8_t* data){return;}
 static void commsSetBrake(uint8_t* data){return;}
-static void commsSetSpeed(uint8_t* data){
-    writeSpeedDAC((( (uint16_t) data[1]) << 8) | data[0]);
-    return;
-}
+
 static uint8_t inputBuf[256];
 
 static packetResponse_t response[] = {

--- a/olympus/drivers/hermes.c
+++ b/olympus/drivers/hermes.c
@@ -16,6 +16,11 @@
 
 hermesData_t hermesData;
 
+void commsSetSpeed(uint8_t* data){
+    uint16_t targetSpeed = (((uint16_t) data[1]) << 8u) | data[0];
+    updateHermesSetSpeedTarget(targetSpeed);
+}
+
 commsStatus_t getHermesStatus()
 {
     return messageSubmodule(HERMES, HERMES_STATUS, NULL, 0u, 0u, SPI_TIMEOUT);

--- a/olympus/drivers/hermes.h
+++ b/olympus/drivers/hermes.h
@@ -27,6 +27,7 @@ typedef struct hermesData{
 
 extern hermesData_t hermesData;
 
+void commsSetSpeed(uint8_t* data);
 commsStatus_t getHermesStatus();
 commsStatus_t updateHermesAutoman();
 commsStatus_t updateHermesSpeed();


### PR DESCRIPTION
-Remove original implementation based on writeSpeedDAC.

Remove speedDAC code in the future.

Closes #69 